### PR TITLE
Update MapBox.cs fixed Shift+Zoom issue when Pan is ActiveTool

### DIFF
--- a/SharpMap.UI/Forms/MapBox.cs
+++ b/SharpMap.UI/Forms/MapBox.cs
@@ -2256,10 +2256,17 @@ namespace SharpMap.Forms
                 {
                     if (_rectangle.Width > 0 && _rectangle.Height > 0)
                     {
+                        var zoomWindowStartPoint = _dragStartPoint;
+                        var zoomWindowEndPoint = new PointF(e.X, e.Y); 
+                    
                         Coordinate lowerLeft;
                         Coordinate upperRight;
-                        GetBounds(_map.ImageToWorld(_dragStartPoint), _map.ImageToWorld(_dragEndPoint),
-                            out lowerLeft, out upperRight);
+                        GetBounds(
+                            _map.ImageToWorld(zoomWindowStartPoint), 
+                            _map.ImageToWorld(zoomWindowEndPoint),
+                            out lowerLeft, 
+                            out upperRight);
+                            
                         _dragEndPoint.X = 0;
                         _dragEndPoint.Y = 0;
 


### PR DESCRIPTION
Fixed the issue when using ZoomWindow.

The issue is that, when the `ActiveTool` is Pan but we decided to apply ToolWindow zoom transform (because Shift modifier is active), `_dragEndPoint` was not set in `MouseMove` method (because we are in Pan mode). 

To fix the problem, mouse event position is used as end point (as in other tools) when mouse click is released.